### PR TITLE
Refactor settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea/
+secrets.json

--- a/materialhospital/settings/base.py
+++ b/materialhospital/settings/base.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 import os
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 # Quick-start development settings - unsuitable for production

--- a/materialhospital/settings/base.py
+++ b/materialhospital/settings/base.py
@@ -10,17 +10,31 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
+import json
 import os
+
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+with open(os.path.join(BASE_DIR, 'secrets.json')) as fh:
+    secrets = json.loads(fh.read())
+
+
+def get_secret(setting, secrets=secrets):
+    try:
+        return secrets[setting]
+    except KeyError:
+        error_msg = "{0} key missing".format(setting)
+        raise ImproperlyConfigured(error_msg)
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'f-oaz_-=btr7sepemdwhgn32b9mn2h7jmd2x7#^mo_0^t5+k^*'
+SECRET_KEY = get_secret('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/materialhospital/settings/local.py
+++ b/materialhospital/settings/local.py
@@ -1,0 +1,3 @@
+from .base import *
+
+DEBUG = True


### PR DESCRIPTION
This splits the settings file creating a base file and a local file to use in development, with DEBUG=True

It also moves SECRET_KEY out of the settings file, because it shouldn't be in a public repository.

You need to create a secrets.json file in the project root with contents:

{ "SECRET_KEY": "<secret>" }

<secret> can be generated by django.core.management.utils.get_random_secret_key()